### PR TITLE
Windows compatibility update

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,10 @@ Currently tested to work on mac supporting windows soon.
 
 # Instructions For PC
 
-> 1. Install MinGW and ncurses
+> 1. Install MinGW
 > 2. Download MinGW: https://sourceforge.net/projects/mingw/
-> 3. Install ncurses for Windows:
-  Use a precompiled library like pdcurses (a Windows-compatible version of ncurses).
-  Download: https://pdcurses.org/
-> 4. Compile The Program By Opening Windows Terminal : gcc -o fruit_game.exe fruit_game.c -lpdcurses
-> 5. Run The Executive Program
+> 3. Compile The Program By Opening Windows Terminal : `gcc catch_the_fruit.c -o catch_the_fruit.exe -lpdcurses -DNCURSES_STATIC` (*Credit to https://stackoverflow.com/a/75704765*)
+> 4. Run The Executive Program
 
 # How To Play the Game?
 

--- a/catch_the_fruit.c
+++ b/catch_the_fruit.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-#include <ncurses.h>
+#include <ncurses/ncurses.h>
 
 #define WIDTH 30
 #define HEIGHT 15
@@ -85,7 +85,7 @@ void loadingScreen() {
     clear();
     mvprintw(HEIGHT / 2, (WIDTH - 13) / 2, "Loading...");
     refresh();
-    sleep(5);  // Pause for 5 seconds
+    _sleep(5);  // Pause for 5 seconds
 }
 
 void draw(Fruit fruit, int basketX, int score, int highScore) {

--- a/catch_the_fruit.c
+++ b/catch_the_fruit.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include <ncurses/ncurses.h>
+#include <unistd.h>
 
 #define WIDTH 30
 #define HEIGHT 15
@@ -85,7 +86,7 @@ void loadingScreen() {
     clear();
     mvprintw(HEIGHT / 2, (WIDTH - 13) / 2, "Loading...");
     refresh();
-    _sleep(5);  // Pause for 5 seconds
+    sleep(5);  // Pause for 5 seconds
 }
 
 void draw(Fruit fruit, int basketX, int score, int highScore) {


### PR DESCRIPTION
## Changes
- catch_the_fruit.c:88 `sleep(5);` returned error on build; added `#include <unistd.h>` for multiplatform compatibility (*credit to https://stackoverflow.com/a/59812756*)
- updated build instructions for Windows (*credit to https://stackoverflow.com/a/75704765*) (*stackoverflow ftw*)
    - removed requirement for pdcurses

## Issues
- unknown compatibility w/ MacOS
- unknown compatibility w/ Windows ver <11
- afaik pdcurses allows features not included w/ base ncurses, may have removed some game features?